### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hacs_action.yml
+++ b/.github/workflows/hacs_action.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/tronity/homeassistant/security/code-scanning/1](https://github.com/tronity/homeassistant/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/hacs_action.yml` at the workflow root so all jobs inherit least-privilege defaults unless overridden.  
The best minimal fix here is:

```yaml
permissions:
  contents: read
```

Place it after the `on:` trigger block (or near the top-level keys before `jobs:`). This does not change workflow functionality for the shown steps and satisfies CodeQL’s requirement to explicitly scope `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
